### PR TITLE
[WIP]Refactor: extract some methods of the 2D renderers from the Engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,11 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{secrets.CODECOV_TOKEN}}
           directory: ./coverage/lcov-report/
           fail_ci_if_error: true
           flags: unittests
-          
+
   e2e:
     runs-on: macos-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Test
         run: npm run test-cov
       - name: Report
-        run: nyc report --reporter=lcov
+        run: ./node_modules/.bin/nyc report --reporter=lcov
       - run: pnpm install codecov -w
       - name: Upload coverage to Codecov
         run: ./node_modules/.bin/codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
         run: npm run build:editor
       - name: Test
         run: npm run test-cov
+      - name: Report
+        run: nyc report --reporter=lcov
       - run: pnpm install codecov -w
       - name: Upload coverage to Codecov
         run: ./node_modules/.bin/codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,6 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          directory: ./coverage/lcov-report/
           fail_ci_if_error: true
           flags: unittests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,13 @@ jobs:
         run: npm run build:editor
       - name: Test
         run: npm run test-cov
-      - name: Report
-        run: ./node_modules/.bin/nyc report --reporter=lcov
-      - run: pnpm install codecov -w
       - name: Upload coverage to Codecov
-        run: ./node_modules/.bin/codecov
-      - run: curl -s https://codecov.io/bash
-
+        uses: codecov/codecov-action@v4
+        with:
+          directory: ./coverage/lcov-report/
+          fail_ci_if_error: true
+          flags: unittests
+          
   e2e:
     runs-on: macos-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: pnpm b:all
 
       - name: Release current monorepo
-        uses: gz65555/publish@v0.1.3
+        uses: gz65555/publish@v0.1.9
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: true

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@galacean/engine-e2e",
   "private": true,
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "license": "MIT",
   "scripts": {
     "case": "vite serve .dev --config .dev/vite.config.js",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@galacean/engine-e2e",
   "private": true,
-  "version": "1.3.11",
+  "version": "1.3.12",
   "license": "MIT",
   "scripts": {
     "case": "vite serve .dev --config .dev/vite.config.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-root",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "packageManager": "pnpm@9.3.0",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-root",
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "packageManager": "pnpm@9.3.0",
   "private": true,
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-core",
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-core",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/core/src/2d/sprite/SpriteMask.ts
+++ b/packages/core/src/2d/sprite/SpriteMask.ts
@@ -16,6 +16,7 @@ import { SpriteModifyFlags } from "../enums/SpriteModifyFlags";
 import { Sprite } from "./Sprite";
 import { Material } from "../../material";
 import { ColorWriteMask, CullMode, RenderQueueType, Shader } from "../../shader";
+import { Engine } from "../../Engine";
 
 /**
  * A component for masking Sprites.
@@ -26,7 +27,7 @@ export class SpriteMask extends Renderer {
   /** @internal */
   static _alphaCutoffProperty: ShaderProperty = ShaderProperty.getByName("renderer_MaskAlphaCutoff");
 
-  static _createSpriteMaskMaterial(engine): Material {
+  static _createSpriteMaskMaterial(engine: Engine): Material {
     const material = new Material(engine, Shader.find("SpriteMask"));
     const renderState = material.renderState;
     renderState.blendState.targetBlendState.colorWriteMask = ColorWriteMask.None;

--- a/packages/core/src/2d/sprite/SpriteMask.ts
+++ b/packages/core/src/2d/sprite/SpriteMask.ts
@@ -14,6 +14,8 @@ import { SimpleSpriteAssembler } from "../assembler/SimpleSpriteAssembler";
 import { SpriteMaskLayer } from "../enums/SpriteMaskLayer";
 import { SpriteModifyFlags } from "../enums/SpriteModifyFlags";
 import { Sprite } from "./Sprite";
+import { Material } from "../../material";
+import { ColorWriteMask, CullMode, RenderQueueType, Shader } from "../../shader";
 
 /**
  * A component for masking Sprites.
@@ -23,6 +25,18 @@ export class SpriteMask extends Renderer {
   static _textureProperty: ShaderProperty = ShaderProperty.getByName("renderer_MaskTexture");
   /** @internal */
   static _alphaCutoffProperty: ShaderProperty = ShaderProperty.getByName("renderer_MaskAlphaCutoff");
+
+  static _createSpriteMaskMaterial(engine): Material {
+    const material = new Material(engine, Shader.find("SpriteMask"));
+    const renderState = material.renderState;
+    renderState.blendState.targetBlendState.colorWriteMask = ColorWriteMask.None;
+    renderState.rasterState.cullMode = CullMode.Off;
+    renderState.stencilState.enabled = true;
+    renderState.depthState.enabled = false;
+    renderState.renderQueueType = RenderQueueType.Transparent;
+    material.isGCIgnored = true;
+    return material;
+  }
 
   /** The mask layers the sprite mask influence to. */
   @assignmentClone

--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -20,6 +20,7 @@ import { SpriteTileMode } from "../enums/SpriteTileMode";
 import { Sprite } from "./Sprite";
 import { Material } from "../../material";
 import { BlendFactor, BlendOperation, CullMode, RenderQueueType, Shader } from "../../shader";
+import { Engine } from "../../Engine";
 
 /**
  * Renders a Sprite for 2D graphics.
@@ -28,7 +29,7 @@ export class SpriteRenderer extends Renderer {
   /** @internal */
   static _textureProperty: ShaderProperty = ShaderProperty.getByName("renderer_SpriteTexture");
 
-  static _createSpriteMaterial(engine, maskInteraction: SpriteMaskInteraction): Material {
+  static _createSpriteMaterial(engine: Engine, maskInteraction: SpriteMaskInteraction): Material {
     const material = new Material(engine, Shader.find("Sprite"));
     const renderState = material.renderState;
     const target = renderState.blendState.targetBlendState;

--- a/packages/core/src/2d/text/TextRenderer.ts
+++ b/packages/core/src/2d/text/TextRenderer.ts
@@ -33,7 +33,7 @@ export class TextRenderer extends Renderer {
   private static _worldPositions = [new Vector3(), new Vector3(), new Vector3(), new Vector3()];
   private static _charRenderInfos: CharRenderInfo[] = [];
 
-  static _createTextMaterial(engine): Material {
+  static _createTextMaterial(engine: Engine): Material {
     const material = new Material(engine, Shader.find("Text"));
     const renderState = material.renderState;
     const target = renderState.blendState.targetBlendState;

--- a/packages/core/src/2d/text/TextRenderer.ts
+++ b/packages/core/src/2d/text/TextRenderer.ts
@@ -9,7 +9,7 @@ import { SubRenderElement } from "../../RenderPipeline/SubRenderElement";
 import { Renderer } from "../../Renderer";
 import { TransformModifyFlags } from "../../Transform";
 import { assignmentClone, deepClone, ignoreClone } from "../../clone/CloneManager";
-import { ShaderData, ShaderProperty } from "../../shader";
+import { BlendFactor, BlendOperation, CullMode, RenderQueueType, Shader, ShaderData, ShaderProperty } from "../../shader";
 import { CompareFunction } from "../../shader/enums/CompareFunction";
 import { ShaderDataGroup } from "../../shader/enums/ShaderDataGroup";
 import { Texture2D } from "../../texture";
@@ -21,6 +21,7 @@ import { CharRenderInfo } from "./CharRenderInfo";
 import { Font } from "./Font";
 import { SubFont } from "./SubFont";
 import { TextUtils } from "./TextUtils";
+import { Material } from "../../material";
 
 /**
  * Renders a text for 2D graphics.
@@ -31,6 +32,23 @@ export class TextRenderer extends Renderer {
   private static _tempVec31 = new Vector3();
   private static _worldPositions = [new Vector3(), new Vector3(), new Vector3(), new Vector3()];
   private static _charRenderInfos: CharRenderInfo[] = [];
+
+  static _createTextMaterial(engine): Material {
+    const material = new Material(engine, Shader.find("Text"));
+    const renderState = material.renderState;
+    const target = renderState.blendState.targetBlendState;
+    target.enabled = true;
+    target.sourceColorBlendFactor = BlendFactor.SourceAlpha;
+    target.destinationColorBlendFactor = BlendFactor.OneMinusSourceAlpha;
+    target.sourceAlphaBlendFactor = BlendFactor.One;
+    target.destinationAlphaBlendFactor = BlendFactor.OneMinusSourceAlpha;
+    target.colorBlendOperation = target.alphaBlendOperation = BlendOperation.Add;
+    renderState.depthState.writeEnabled = false;
+    renderState.rasterState.cullMode = CullMode.Off;
+    renderState.renderQueueType = RenderQueueType.Transparent;
+    material.isGCIgnored = true;
+    return material;
+  }
 
   /** @internal */
   @ignoreClone

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -7,7 +7,7 @@ import {
   IXRDevice
 } from "@galacean/engine-design";
 import { Color } from "@galacean/engine-math";
-import { SpriteMaskInteraction } from "./2d";
+import { SpriteMask, SpriteMaskInteraction, SpriteRenderer, TextRenderer } from "./2d";
 import { CharRenderInfo } from "./2d/text/CharRenderInfo";
 import { Font } from "./2d/text/Font";
 import { BasicResources } from "./BasicResources";
@@ -30,18 +30,12 @@ import { Material } from "./material/Material";
 import { ParticleBufferUtils } from "./particle/ParticleBufferUtils";
 import { PhysicsScene } from "./physics/PhysicsScene";
 import { ColliderShape } from "./physics/shape/ColliderShape";
-import { CompareFunction } from "./shader";
 import { Shader } from "./shader/Shader";
 import { ShaderMacro } from "./shader/ShaderMacro";
 import { ShaderMacroCollection } from "./shader/ShaderMacroCollection";
 import { ShaderPass } from "./shader/ShaderPass";
 import { ShaderPool } from "./shader/ShaderPool";
 import { ShaderProgramPool } from "./shader/ShaderProgramPool";
-import { BlendFactor } from "./shader/enums/BlendFactor";
-import { BlendOperation } from "./shader/enums/BlendOperation";
-import { ColorWriteMask } from "./shader/enums/ColorWriteMask";
-import { CullMode } from "./shader/enums/CullMode";
-import { RenderQueueType } from "./shader/enums/RenderQueueType";
 import { RenderState } from "./shader/state/RenderState";
 import { Texture2D, TextureFormat } from "./texture";
 import { ClearableObjectPool } from "./utils/ClearableObjectPool";
@@ -240,17 +234,11 @@ export class Engine extends EventDispatcher {
     this._canvas = canvas;
 
     const { _spriteDefaultMaterials: spriteDefaultMaterials } = this;
-    this._spriteDefaultMaterial = spriteDefaultMaterials[SpriteMaskInteraction.None] = this._createSpriteMaterial(
-      SpriteMaskInteraction.None
-    );
-    spriteDefaultMaterials[SpriteMaskInteraction.VisibleInsideMask] = this._createSpriteMaterial(
-      SpriteMaskInteraction.VisibleInsideMask
-    );
-    spriteDefaultMaterials[SpriteMaskInteraction.VisibleOutsideMask] = this._createSpriteMaterial(
-      SpriteMaskInteraction.VisibleOutsideMask
-    );
-    this._textDefaultMaterial = this._createTextMaterial();
-    this._spriteMaskDefaultMaterial = this._createSpriteMaskMaterial();
+    this._spriteDefaultMaterial = spriteDefaultMaterials[SpriteMaskInteraction.None] = SpriteRenderer._createSpriteMaterial(this, SpriteMaskInteraction.None);
+    spriteDefaultMaterials[SpriteMaskInteraction.VisibleInsideMask] = SpriteRenderer._createSpriteMaterial(this, SpriteMaskInteraction.VisibleInsideMask);
+    spriteDefaultMaterials[SpriteMaskInteraction.VisibleOutsideMask] = SpriteRenderer._createSpriteMaterial(this, SpriteMaskInteraction.VisibleOutsideMask);
+    this._textDefaultMaterial = TextRenderer._createTextMaterial(this);
+    this._spriteMaskDefaultMaterial = SpriteMask._createSpriteMaskMaterial(this);
     this._textDefaultFont = Font.createFromOS(this, "Arial");
     this._textDefaultFont.isGCIgnored = true;
 
@@ -581,63 +569,7 @@ export class Engine extends EventDispatcher {
     return Promise.all(initializePromises).then(() => this);
   }
 
-  private _createSpriteMaterial(maskInteraction: SpriteMaskInteraction): Material {
-    const material = new Material(this, Shader.find("Sprite"));
-    const renderState = material.renderState;
-    const target = renderState.blendState.targetBlendState;
-    target.enabled = true;
-    target.sourceColorBlendFactor = BlendFactor.SourceAlpha;
-    target.destinationColorBlendFactor = BlendFactor.OneMinusSourceAlpha;
-    target.sourceAlphaBlendFactor = BlendFactor.One;
-    target.destinationAlphaBlendFactor = BlendFactor.OneMinusSourceAlpha;
-    target.colorBlendOperation = target.alphaBlendOperation = BlendOperation.Add;
-    if (maskInteraction !== SpriteMaskInteraction.None) {
-      const stencilState = renderState.stencilState;
-      stencilState.enabled = true;
-      stencilState.writeMask = 0x00;
-      stencilState.referenceValue = 1;
-      const compare =
-        maskInteraction === SpriteMaskInteraction.VisibleInsideMask
-          ? CompareFunction.LessEqual
-          : CompareFunction.Greater;
-      stencilState.compareFunctionFront = compare;
-      stencilState.compareFunctionBack = compare;
-    }
-    renderState.depthState.writeEnabled = false;
-    renderState.rasterState.cullMode = CullMode.Off;
-    renderState.renderQueueType = RenderQueueType.Transparent;
-    material.isGCIgnored = true;
-    return material;
-  }
 
-  private _createSpriteMaskMaterial(): Material {
-    const material = new Material(this, Shader.find("SpriteMask"));
-    const renderState = material.renderState;
-    renderState.blendState.targetBlendState.colorWriteMask = ColorWriteMask.None;
-    renderState.rasterState.cullMode = CullMode.Off;
-    renderState.stencilState.enabled = true;
-    renderState.depthState.enabled = false;
-    renderState.renderQueueType = RenderQueueType.Transparent;
-    material.isGCIgnored = true;
-    return material;
-  }
-
-  private _createTextMaterial(): Material {
-    const material = new Material(this, Shader.find("Text"));
-    const renderState = material.renderState;
-    const target = renderState.blendState.targetBlendState;
-    target.enabled = true;
-    target.sourceColorBlendFactor = BlendFactor.SourceAlpha;
-    target.destinationColorBlendFactor = BlendFactor.OneMinusSourceAlpha;
-    target.sourceAlphaBlendFactor = BlendFactor.One;
-    target.destinationAlphaBlendFactor = BlendFactor.OneMinusSourceAlpha;
-    target.colorBlendOperation = target.alphaBlendOperation = BlendOperation.Add;
-    renderState.depthState.writeEnabled = false;
-    renderState.rasterState.cullMode = CullMode.Off;
-    renderState.renderQueueType = RenderQueueType.Transparent;
-    material.isGCIgnored = true;
-    return material;
-  }
 
   private _onDeviceLost(): void {
     this._isDeviceLost = true;

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -234,9 +234,22 @@ export class Engine extends EventDispatcher {
     this._canvas = canvas;
 
     const { _spriteDefaultMaterials: spriteDefaultMaterials } = this;
-    this._spriteDefaultMaterial = spriteDefaultMaterials[SpriteMaskInteraction.None] = SpriteRenderer._createSpriteMaterial(this, SpriteMaskInteraction.None);
-    spriteDefaultMaterials[SpriteMaskInteraction.VisibleInsideMask] = SpriteRenderer._createSpriteMaterial(this, SpriteMaskInteraction.VisibleInsideMask);
-    spriteDefaultMaterials[SpriteMaskInteraction.VisibleOutsideMask] = SpriteRenderer._createSpriteMaterial(this, SpriteMaskInteraction.VisibleOutsideMask);
+
+    this._spriteDefaultMaterial = spriteDefaultMaterials[SpriteMaskInteraction.None] = SpriteRenderer._createSpriteMaterial(
+      this,
+      SpriteMaskInteraction.None
+    );
+
+    spriteDefaultMaterials[SpriteMaskInteraction.VisibleInsideMask] = SpriteRenderer._createSpriteMaterial(
+      this,
+      SpriteMaskInteraction.VisibleInsideMask
+    );
+
+    spriteDefaultMaterials[SpriteMaskInteraction.VisibleOutsideMask] = SpriteRenderer._createSpriteMaterial(
+      this,
+      SpriteMaskInteraction.VisibleOutsideMask
+    );
+
     this._textDefaultMaterial = TextRenderer._createTextMaterial(this);
     this._spriteMaskDefaultMaterial = SpriteMask._createSpriteMaskMaterial(this);
     this._textDefaultFont = Font.createFromOS(this, "Arial");

--- a/packages/core/src/lighting/DirectLight.ts
+++ b/packages/core/src/lighting/DirectLight.ts
@@ -1,4 +1,4 @@
-import { Color, Matrix, Vector3 } from "@galacean/engine-math";
+import { Color, Vector3 } from "@galacean/engine-math";
 import { ColorSpace } from "../enums/ColorSpace";
 import { ShaderData } from "../shader";
 import { ShaderProperty } from "../shader/ShaderProperty";
@@ -21,6 +21,12 @@ export class DirectLight extends Light {
     shaderData.setFloatArray(DirectLight._directionProperty, data.direction);
   }
 
+  /**
+   * The offset distance in the opposite direction of light direction when generating shadows.
+   * @remarks Increasing this value can avoid the holes in the shadow caused by low polygon models.
+   */
+  shadowNearPlaneOffset = 0.1;
+
   private _reverseDirection: Vector3 = new Vector3();
 
   /**
@@ -36,13 +42,6 @@ export class DirectLight extends Light {
   get reverseDirection(): Vector3 {
     Vector3.scale(this.direction, -1, this._reverseDirection);
     return this._reverseDirection;
-  }
-
-  /**
-   * @internal
-   */
-  override get _shadowProjectionMatrix(): Matrix {
-    throw "Unknown!";
   }
 
   /**

--- a/packages/core/src/lighting/Light.ts
+++ b/packages/core/src/lighting/Light.ts
@@ -23,7 +23,11 @@ export abstract class Light extends Component {
   shadowBias = 1;
   /** Shadow mapping normal-based bias. */
   shadowNormalBias = 1;
-  /** Near plane value to use for shadow frustums. */
+
+  /**
+   * @deprecated
+   * Please use `shadowNearPlaneOffset` instead.
+   */
   shadowNearPlane = 0.1;
 
   /** @internal */
@@ -76,11 +80,6 @@ export abstract class Light extends Component {
     Matrix.invert(this.viewMatrix, this._inverseViewMat);
     return this._inverseViewMat;
   }
-
-  /**
-   * @internal
-   */
-  abstract get _shadowProjectionMatrix(): Matrix;
 
   /**
    * Light Color, include intensity.

--- a/packages/core/src/lighting/PointLight.ts
+++ b/packages/core/src/lighting/PointLight.ts
@@ -1,4 +1,4 @@
-import { Color, Matrix, Vector3 } from "@galacean/engine-math";
+import { Color, Vector3 } from "@galacean/engine-math";
 import { ColorSpace } from "../enums/ColorSpace";
 import { ShaderData } from "../shader";
 import { ShaderProperty } from "../shader/ShaderProperty";
@@ -31,13 +31,6 @@ export class PointLight extends Light {
    */
   get position(): Vector3 {
     return this.entity.transform.worldPosition;
-  }
-
-  /**
-   * @internal
-   */
-  override get _shadowProjectionMatrix(): Matrix {
-    throw "Unknown!";
   }
 
   /**

--- a/packages/core/src/lighting/SpotLight.ts
+++ b/packages/core/src/lighting/SpotLight.ts
@@ -64,16 +64,6 @@ export class SpotLight extends Light {
   /**
    * @internal
    */
-  override get _shadowProjectionMatrix(): Matrix {
-    const matrix = this._projectMatrix;
-    const fov = Math.min(Math.PI / 2, this.angle * 2 * Math.sqrt(2));
-    Matrix.perspective(fov, 1, this.shadowNearPlane, this.distance + this.shadowNearPlane, matrix);
-    return matrix;
-  }
-
-  /**
-   * @internal
-   */
   _appendData(lightIndex: number, data: ISpotLightShaderData): void {
     const cullingMaskStart = lightIndex * 2;
     const colorStart = lightIndex * 3;

--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -112,22 +112,23 @@ export class Shader implements IReferable {
             passInfo.tags
           );
 
-          const renderStates = passInfo.renderStates;
-          const renderState = new RenderState();
+          const { constantMap, variableMap } = passInfo.renderStates;
+          // Compatible shader lab no render state use material `renderState` to modify render state
+          if (Object.keys(constantMap).length > 0 || Object.keys(variableMap).length > 0) {
+            // Parse const render state
+            const renderState = new RenderState();
+            shaderPassContent._renderState = renderState;
+            for (let k in constantMap) {
+              Shader._applyConstRenderStates(renderState, <RenderStateElementKey>parseInt(k), constantMap[k]);
+            }
 
-          shaderPassContent._renderState = renderState;
-          // Parse const render state
-          const { constantMap, variableMap } = renderStates;
-          for (let k in constantMap) {
-            Shader._applyConstRenderStates(renderState, <RenderStateElementKey>parseInt(k), constantMap[k]);
+            // Parse variable render state
+            const renderStateDataMap = {} as Record<number, ShaderProperty>;
+            for (let k in variableMap) {
+              renderStateDataMap[k] = ShaderProperty.getByName(variableMap[k]);
+            }
+            shaderPassContent._renderStateDataMap = renderStateDataMap;
           }
-
-          // Parse variable render state
-          const renderStateDataMap = {} as Record<number, ShaderProperty>;
-          for (let k in variableMap) {
-            renderStateDataMap[k] = ShaderProperty.getByName(variableMap[k]);
-          }
-          shaderPassContent._renderStateDataMap = renderStateDataMap;
 
           return shaderPassContent;
         });

--- a/packages/core/src/shaderlib/particle/velocity_over_lifetime_module.glsl
+++ b/packages/core/src/shaderlib/particle/velocity_over_lifetime_module.glsl
@@ -66,7 +66,7 @@ vec3 computeParticlePosition(in vec3 startVelocity, in vec3 lifeVelocity, in flo
 
         #if defined(RENDERER_VOL_CURVE) || defined(RENDERER_VOL_RANDOM_CURVE)
             lifePosition = vec3(
-            evaluateParticleCurveCumulative(renderer_VOLMaxGradientX, normalizedAge)
+            evaluateParticleCurveCumulative(renderer_VOLMaxGradientX, normalizedAge),
             evaluateParticleCurveCumulative(renderer_VOLMaxGradientY, normalizedAge),
             evaluateParticleCurveCumulative(renderer_VOLMaxGradientZ, normalizedAge));
 

--- a/packages/core/src/shadow/CascadedShadowCasterPass.ts
+++ b/packages/core/src/shadow/CascadedShadowCasterPass.ts
@@ -187,7 +187,7 @@ export class CascadedShadowCasterPass extends PipelinePass {
         lightSide,
         lightForward,
         j,
-        light.shadowNearPlane,
+        light.shadowNearPlaneOffset,
         shadowTileResolution,
         shadowSliceData,
         shadowMatrices

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-design",
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-design",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/galacean/package.json
+++ b/packages/galacean/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/galacean/package.json
+++ b/packages/galacean/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine",
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-loader",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-loader",
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-math",
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-math",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/physics-lite/package.json
+++ b/packages/physics-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-physics-lite",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/physics-lite/package.json
+++ b/packages/physics-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-physics-lite",
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/physics-physx/package.json
+++ b/packages/physics-physx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-physics-physx",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/physics-physx/package.json
+++ b/packages/physics-physx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-physics-physx",
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/rhi-webgl/package.json
+++ b/packages/rhi-webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-rhi-webgl",
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "repository": {
     "url": "https://github.com/galacean/engine.git"
   },

--- a/packages/rhi-webgl/package.json
+++ b/packages/rhi-webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-rhi-webgl",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "repository": {
     "url": "https://github.com/galacean/engine.git"
   },

--- a/packages/shader-lab/package.json
+++ b/packages/shader-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-shader-lab",
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/shader-lab/package.json
+++ b/packages/shader-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-shader-lab",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/xr-webxr/package.json
+++ b/packages/xr-webxr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-xr-webxr",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/xr-webxr/package.json
+++ b/packages/xr-webxr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-xr-webxr",
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-xr",
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galacean/engine-xr",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@galacean/engine-tests",
   "private": true,
-  "version": "1.3.11",
+  "version": "1.3.12",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/module.js",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@galacean/engine-tests",
   "private": true,
-  "version": "1.3.12",
+  "version": "0.0.0-experimental-1.3-xr.10",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/module.js",


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Extract some methods of the 2D renderers from the Engine. The code of Engine should be clean!

Just like this._textDefaultFont is implemented through Font.createFromOS, it would be more reasonable for _spriteDefaultMaterial to be implemented through the static method of its renderer class.

